### PR TITLE
Add guard to draw

### DIFF
--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -333,7 +333,7 @@ function ZoomRegion{I<:Integer}(inds::Tuple{AbstractUnitRange{I},AbstractUnitRan
     fullview = XY(ci[2], ci[1])
     ZoomRegion(fullview, fullview)
 end
-ZoomRegion(img::AbstractMatrix) = ZoomRegion(indices(img))
+ZoomRegion(img) = ZoomRegion(indices(img))
 function ZoomRegion(fullview::XY, bb::BoundingBox)
     xview = oftype(fullview.x, bb.xmin..bb.xmax)
     yview = oftype(fullview.y, bb.ymin..bb.ymax)

--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -265,7 +265,7 @@ This would paint an image-Signal `imgsig` onto the canvas and then
 draw a red circle centered on `xsig`, `ysig`.
 """
 function Gtk.draw(drawfun::Function, c::Canvas, signals::Signal...)
-    draw(c.widget) do widget
+    @guarded draw(c.widget) do widget
         yield()  # allow the Gtk event queue to run
         drawfun(widget, map(value, signals)...)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -333,6 +333,10 @@ end
     destroy(win)
 end
 
+# For testing ZoomRegion support for non-AbstractArray objects
+immutable Foo end
+Base.indices(::Foo) = (Base.OneTo(7), Base.OneTo(9))
+
 @testset "Zoom/pan" begin
     zr = ZoomRegion((1:80, 1:100))  # y, x order
     zrz = GtkReactive.zoom(zr, 0.5)
@@ -386,6 +390,10 @@ end
     @test zr.fullview.x == 1..100
     @test zr.currentview.y == 3..5
     @test zr.currentview.x == 4..7
+
+    zr = ZoomRegion(Foo())
+    @test zr.fullview.y == 1..7
+    @test zr.fullview.x == 1..9
 end
 
 ### Simulate the mouse clicks, etc. to trigger zoom/pan


### PR DESCRIPTION
This prevents "catastrophic" behavior (aka, restart your julia session) if the user's draw function has an error.

Also broadens `ZoomRegion` to support things that aren't AbstractArrays.
