### PR TITLE
Add various convenience functions, mask modifier bits

### DIFF
--- a/src/GtkReactive.jl
+++ b/src/GtkReactive.jl
@@ -58,7 +58,8 @@ Base.push!(w::Widget, val) = push!(signal(w), val)
 Base.show(io::IO, w::Widget) = print(io, typeof(widget(w)), " with ", signal(w))
 Gtk.destroy(w::Widget) = destroy(widget(w))
 Reactive.value(w::Widget) = value(signal(w))
-Base.map(f, w::Widget; kwargs...) = map(f, signal(w); kwargs...)
+Base.map(f, w::Widget, ws::Widget...; kwargs...) = map(f, signal(w), map(signal, ws)...; kwargs...)
+Base.foreach(f, w::Widget, ws::Widget...; kwargs...) = foreach(f, signal(w), map(signal, ws)...; kwargs...)
 
 # Define specific widgets
 include("widgets.jl")

--- a/src/GtkReactive.jl
+++ b/src/GtkReactive.jl
@@ -87,6 +87,9 @@ Gtk.setproperty!(w::Union{Widget,Canvas}, key, val) = setproperty!(widget(w), ke
 Gtk.getproperty(w::Union{Widget,Canvas}, key) = getproperty(widget(w), key)
 Gtk.getproperty{T}(w::Union{Widget,Canvas}, key, ::Type{T}) = getproperty(widget(w), key, T)
 
+Base.unsafe_convert(::Type{Ptr{Gtk.GLib.GObject}}, w::Union{Widget,Canvas}) =
+    Base.unsafe_convert(Ptr{Gtk.GLib.GObject}, widget(w))
+
 Graphics.getgc(c::Canvas) = getgc(c.widget)
 Graphics.width(c::Canvas) = Graphics.width(c.widget)
 Graphics.height(c::Canvas) = height(c.widget)

--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -349,6 +349,8 @@ end
 
 reset(zr::ZoomRegion) = ZoomRegion(zr.fullview, zr.fullview)
 
+Base.indices(zr::ZoomRegion) = map(UnitRange, (zr.currentview.y, zr.currentview.x))
+
 function interior(iv::ClosedInterval, limits::AbstractInterval)
     imin, imax = minimum(iv), maximum(iv)
     lmin, lmax = minimum(limits), maximum(limits)

--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -453,8 +453,8 @@ You can flip the direction of either pan operation with `xpanflip` and
 """
 function init_pan_scroll{U,T}(canvas::Canvas{U},
                               zr::Signal{ZoomRegion{T}},
-                              filter_x::Function = evt->evt.modifiers == SHIFT || evt.direction == LEFT || evt.direction == RIGHT,
-                              filter_y::Function = evt->evt.modifiers == 0 && (evt.direction == UP || evt.direction == DOWN),
+                              filter_x::Function = evt->(evt.modifiers & 0x0f) == SHIFT || evt.direction == LEFT || evt.direction == RIGHT,
+                              filter_y::Function = evt->(evt.modifiers & 0x0f) == 0 && (evt.direction == UP || evt.direction == DOWN),
                               xpanflip = false,
                               ypanflip  = false)
     enabled = Signal(true)
@@ -525,7 +525,7 @@ function init_pan_drag{U,T}(canvas::Canvas{U},
     end
     Dict("enabled"=>enabled, "active"=>active, "init"=>init, "drag"=>drag, "finish"=>finish)
 end
-pandrag_button(btn) = btn.button == 1 && btn.modifiers == 0
+pandrag_button(btn) = btn.button == 1 && (btn.modifiers & 0x0f) == 0
 pandrag_init_default(btn) = btn.clicktype == BUTTON_PRESS && pandrag_button(btn)
 
 """
@@ -558,7 +558,7 @@ zooming with `flip`.
 """
 function init_zoom_scroll{U,T}(canvas::Canvas{U},
                                zr::Signal{ZoomRegion{T}},
-                               filter::Function = evt->evt.modifiers == CONTROL,
+                               filter::Function = evt->(evt.modifiers & 0x0f) == CONTROL,
                                focus::Symbol = :pointer,
                                factor = 2.0,
                                flip = false)

--- a/src/rubberband.jl
+++ b/src/rubberband.jl
@@ -60,8 +60,8 @@ function init_zoom_rubberband{U,T}(canvas::Canvas{U},
     Dict("enabled"=>enabled, "active"=>active, "init"=>init, "drag"=>drag, "finish"=>finish)
 end
 
-zrb_init_default(btn) = btn.button == 1 && btn.clicktype == BUTTON_PRESS && btn.modifiers == CONTROL
-zrb_reset_default(btn) = btn.button == 1 && btn.clicktype == DOUBLE_BUTTON_PRESS && btn.modifiers == CONTROL
+zrb_init_default(btn) = btn.button == 1 && btn.clicktype == BUTTON_PRESS && (btn.modifiers & 0x0f) == CONTROL
+zrb_reset_default(btn) = btn.button == 1 && btn.clicktype == DOUBLE_BUTTON_PRESS && (btn.modifiers & 0x0f) == CONTROL
 
 # For rubberband, we draw the selection region on the front canvas, and repair
 # by copying from the back.

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -273,7 +273,7 @@ togglebutton(; value=false, widget=nothing, signal=nothing, label="", own=nothin
 
 immutable Button <: InputWidget{Void}
     signal::Signal{Void}
-    widget::GtkButtonLeaf
+    widget::Union{GtkButtonLeaf,GtkToolButtonLeaf}
     id::Culong
 
     function (::Type{Button})(signal::Signal{Void}, widget, id)
@@ -283,7 +283,7 @@ immutable Button <: InputWidget{Void}
     end
 end
 
-button(signal::Signal, widget::GtkButtonLeaf, id) =
+button(signal::Signal, widget::Union{GtkButtonLeaf,GtkToolButtonLeaf}, id) =
     Button(signal, widget, id)
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -559,6 +559,11 @@ destroy(win)
     end
 end
 
+@testset "Layout" begin
+    g = Grid()
+    g[1,1] = textbox("hello")
+end
+
 # Ensure that the examples run (but the Reactive queue is stopped, so
 # they won't work unless one calls `@async Reactive.run()` manually)
 examplepath = joinpath(dirname(dirname(@__FILE__)), "examples")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -292,7 +292,7 @@ end
 # @testset "Canvas events" begin
     win = Window() |> (c = canvas(UserUnit))
     showall(win)
-    sleep(0.1)
+    sleep(0.2)
     lastevent = Ref("nothing")
     press   = map(btn->lastevent[] = "press",   c.mouse.buttonpress)
     release = map(btn->lastevent[] = "release", c.mouse.buttonrelease)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,6 +81,17 @@ include("tools.jl")
     push!(num, 8)
     rr()
     @test getproperty(num, :text, String) == "8"
+    meld = map(txt, num) do t, n
+        join((t, n), 'X')
+    end
+    rr()
+    @test value(meld) == "other directionX8"
+    push!(num, 4)
+    rr()
+    @test value(meld) == "other directionX4"
+    push!(txt, "4")
+    rr()
+    @test value(meld) == "4X4"
     destroy(win)
 
     ## textarea (aka TextView)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,6 +187,9 @@ rr()
 @test counter == cc+1
 destroy(w)
 
+# Make sure we can also put a ToolButton in a Button
+button(; widget=ToolButton("Save as..."))
+
 if Gtk.libgtk_version >= v"3.10"
     # To support GtkBuilder, we need this as the minimum libgtk version
     @testset "Compound widgets" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -436,6 +436,7 @@ Base.indices(::Foo) = (Base.OneTo(7), Base.OneTo(9))
     @test zr.fullview.y == 1..100
     @test zr.currentview.x == 8..12
     @test zr.currentview.y == 11..20
+    @test indices(zr) == (11:20, 8:12)
 end
 
 ### Simulate the mouse clicks, etc. to trigger zoom/pan

--- a/test/tools.jl
+++ b/test/tools.jl
@@ -1,5 +1,6 @@
 rr() = (Reactive.run_till_now(); yield())
 function run_till_empty()
+    yield()
     while !isempty(Reactive._messages.data)
         rr()
     end


### PR DESCRIPTION
This adds a number of convenience methods. Perhaps the most important part of this, however, is to mask all but the 4 lowest bits of event modifiers. It seems likely to fix #24, though obviously I'm only guessing.

Also addresses #15.