### PR TITLE
Add a few convenience methods and improve docs

### DIFF
--- a/docs/src/controls.md
+++ b/docs/src/controls.md
@@ -26,12 +26,14 @@ Gtk.GtkScaleLeaf
 
 At present, this slider is not affiliated with any window. Let's
 create one and add the slider to the window. We'll put it inside a
-`Box` so that we can later add more things to this GUI:
+`Box` so that we can later add more things to this GUI (this
+illustrates usage of some of
+[Gtk's layout tools](http://juliagraphics.github.io/Gtk.jl/latest/manual/layout.html):
 
 ```jldoctest demo1
 julia> win = Window("Testing") |> (bx = Box(:v));  # a window containing a vertical Box for layout
 
-julia> push!(bx, sl);    # put the slider in the box, shorthand for push!(bx, widget(sl));
+julia> push!(bx, sl);    # put the slider in the box, shorthand for push!(bx, widget(sl))
 
 julia> showall(win);
 ```
@@ -46,8 +48,8 @@ that we used to create `sl`. Now drag the slider all the way to the
 right, and then see what happened to `sl`:
 
 ```@meta
-push!(sl, 11)
-Reactive.run_till_now()
+push!(sl, 11)    # Updates the value of a Signal. See the Reactive.jl docs.
+Reactive.run_till_now() # remember, Reactive is asynchronous! This forces the push! to run now.
 sleep(1)
 Reactive.run_till_now()
 ```
@@ -92,9 +94,9 @@ to allow updates to propagate to a second `Signal`:
 ```
 a = button("a")
 x = Signal(1)
-y_temp = map(sin, x)
+y_temp = map(sin, x)    # see the Reactive.jl documentation for info about using `map`
 y = map(_ -> value(y_temp), a)
 ```
-Subsequent `push!`es into `x` will update `y_temp`, but not `y`. Only 
+Subsequent `push!`es into `x` will update `y_temp`, but not `y`. Only
 after the user presses on the `a` button does `y` get updated with the
 last value of `y_temp`.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -36,6 +36,19 @@ GtkReactive.MouseScroll
 
 ```@docs
 ZoomRegion
+```
+
+Note that if you create a `zrsig::Signal{ZoomRegion}`, then
+```julia
+push!(zrsig, XY(1..3, 1..5))
+push!(zrsig, (1..5, 1..3))
+push!(zrsig, (1:5, 1:3))
+```
+would all update the value of the `currentview` field to the same
+value (`x = 1..3` and `y = 1..5`).
+
+
+```@docs
 pan_x
 pan_y
 zoom

--- a/src/GtkReactive.jl
+++ b/src/GtkReactive.jl
@@ -112,9 +112,9 @@ function Graphics.BoundingBox(xy::XY)
     BoundingBox(minimum(xy.x), maximum(xy.x), minimum(xy.y), maximum(xy.y))
 end
 
-function Base.push!{T}(zr::Signal{ZoomRegion{T}}, cv::XY{ClosedInterval{T}})
+function Base.push!{T,S}(zr::Signal{ZoomRegion{T}}, cv::XY{ClosedInterval{S}})
     fv = value(zr).fullview
-    push!(zr, ZoomRegion(fv, cv))
+    push!(zr, ZoomRegion{T}(fv, cv))
 end
 
 function Base.push!{T}(zr::Signal{ZoomRegion{T}}, inds::Tuple{ClosedInterval,ClosedInterval})

--- a/src/GtkReactive.jl
+++ b/src/GtkReactive.jl
@@ -25,7 +25,7 @@ export set_coordinates, BoundingBox, SHIFT, CONTROL, MOD1, UP, DOWN, LEFT, RIGHT
 ## Exports
 export slider, button, checkbox, togglebutton, dropdown, textbox, textarea, spinbutton
 export label
-export canvas, DeviceUnit, UserUnit, XY, MouseButton, MouseScroll
+export canvas, DeviceUnit, UserUnit, XY, MouseButton, MouseScroll, MouseHandler
 export player
 export signal, widget, frame
 # Zoom/pan


### PR DESCRIPTION
Some of the types printed rather verbosely, and we were missing some obvious conversion methods to make people's lives easier.

The documentation has been improved to be more newbie-friendly, with crosslinks to Gtk and Reactive documentation.
