### PR TITLE
Pull request/8f46b0c7

### DIFF
--- a/src/extrawidgets.jl
+++ b/src/extrawidgets.jl
@@ -128,7 +128,7 @@ end
 
 Return a time widget that includes the `Time` and a `GtkBox` with the hour, minute, and second widgets in it.
 """
-function timewidget(t0::T) where T <: Dates.AbstractTime
+function timewidget(t0::Dates.Time)
     t = Signal(t0)
     # values
     h = map(x -> Dates.value(Dates.Hour(x)), t)

--- a/src/extrawidgets.jl
+++ b/src/extrawidgets.jl
@@ -121,88 +121,6 @@ Base.unsafe_convert(::Type{Ptr{Gtk.GLib.GObject}}, p::PlayerWithTextbox) =
 immutable TimeWidget <: InputWidget{Dates.Time}
     signal::Signal{Dates.Time}
     widget::GtkBox
-    id::Culong
-    preserved::Vector
-
-    function (::Type{TimeWidget})(signal::Signal{Dates.Time}, widget, id, preserved)
-        obj = new(signal, widget, id, preserved)
-        gc_preserve(widget, obj)
-        obj
-    end
-end
-TimeWidget(signal::Signal{Dates.Time}, widget::GtkBox, id, preserved) =
-    TimeWidget(signal, widget, id, preserved)
-
-timewidget(signal::Signal, widget::GtkBox, id, preserved = []) =
-    TimeWidget(signal, widget, id, preserved)
-
-"""
-    timewidget(time; widget=nothing, value=nothing, signal=nothing, orientation="vertical")
-
-Create a timewidget widget with the specified `time`. Optionally provide:
-  - the GtkBox `widget` (by default, creates a new one)
-  - the starting `value` (defaults to `Time(0,0,0)`)
-  - the (Reactive.jl) `signal` coupled to this timewidget (by default, creates a new signal)
-  - the `orientation` of the timewidget.
-"""
-function timewidget(time::Dates.Time;
-                   widget=nothing,
-                   value=nothing,
-                   signal=nothing,
-                   orientation="vertical",
-                   syncsig=true,
-                   own=nothing)
-
-
-
-    signalin = signal
-    signal, value = init_wsigval(Dates.Time, signal, value; default=Dates.Time(0,0,0))
-    if own == nothing
-        own = signal != signalin
-    end
-    if widget == nothing
-        widget = GtkScale(lowercase(first(orientation)) == 'v',
-                          first(range), last(range), step(range))
-        Gtk.G_.size_request(widget, 200, -1)
-    else
-        adj = Gtk.Adjustment(widget)
-        Gtk.G_.lower(adj, first(range))
-        Gtk.G_.upper(adj, last(range))
-        Gtk.G_.step_increment(adj, step(range))
-    end
-    Gtk.G_.value(widget, value)
-
-    ## widget -> signal
-    id = signal_connect(widget, :value_changed) do w
-        push!(signal, defaultgetter(w))
-    end
-
-    ## signal -> widget
-    preserved = []
-    if syncsig
-        push!(preserved, init_signal2widget(widget, id, signal))
-    end
-    if own
-        ondestroy(widget, preserved)
-    end
-
-    TimeWidget(signal, widget, id, preserved)
-end
-
-
-
-
-
-
-
-
-
-
-
-
-immutable TimeWidget
-    signal::Signal{Dates.Time}
-    widget::GtkBox
 end
 
 """
@@ -256,12 +174,4 @@ function timewidget(t0::Dates.Time)
     # done
     return TimeWidget(t, b)
 end
-
-# These would be cool to use, but I'm not sure if you want me to import all of these from Reactive, or if I should some how make TimeWidget a subtype of InputWidget. All my attempts to do either failed...
-# signal(w::TimeWidget) = w.signal
-# value(w::TimeWidget) = value(signal(w))
-# Dates.Time(w::TimeWidget) = value(w)
-# widget(w::TimeWidget) = w.widget
-# Reactive.push!(w::TimeWidget, t::Dates.Time) = push!(signal(w), t)
-# Reactive.map(f::Function, w::TimeWidget) = map(f, signal(w))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -204,7 +204,7 @@ include("tools.jl")
     @test G_.orientation(Orientable(widget(s))) == Gtk.GConstants.GtkOrientation.VERTICAL
     destroy(s)
 
-    @test_nowarn timewidget(now())
+    @test_nowarn timewidget(Dates.Time(1,1,1))
 end
 
 ## button


### PR DESCRIPTION
This is now functional. So a `TimeWidget` can now be pushed to, maped, and all. I made it a subtype of `inputWidget{Dates.Time}`, and that did the trick. 