### PR TITLE
Pull request/ccb30996

### DIFF
--- a/src/GtkReactive.jl
+++ b/src/GtkReactive.jl
@@ -23,7 +23,7 @@ export set_coordinates, BoundingBox, SHIFT, CONTROL, MOD1, UP, DOWN, LEFT, RIGHT
        BUTTON_PRESS, DOUBLE_BUTTON_PRESS, destroy
 
 ## Exports
-export slider, button, checkbox, togglebutton, dropdown, textbox, textarea, spinbutton, cyclicspinbutton
+export slider, button, checkbox, togglebutton, dropdown, textbox, textarea, spinbutton, cyclicspinbutton, progressbar
 export label
 export canvas, DeviceUnit, UserUnit, XY, MouseButton, MouseScroll, MouseHandler
 export player, timewidget

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -946,3 +946,63 @@ function cyclicspinbutton{T}(range::Range{T}, carry_up::Signal{Bool};
 
     CyclicSpinButton(signal, widget, id, preserved)
 end
+
+
+
+
+######################## ProgressBar #########################
+
+immutable ProgressBar{T <: Number} <: Widget
+    signal::Signal{T}
+    widget::GtkProgressBarLeaf
+    preserved::Vector{Any}
+
+    function (::Type{ProgressBar{T}}){T}(signal::Signal{T}, widget, preserved)
+        obj = new{T}(signal, widget, preserved)
+        gc_preserve(widget, obj)
+        obj
+    end
+end
+ProgressBar{T}(signal::Signal{T}, widget::GtkProgressBarLeaf, preserved) =
+    ProgressBar{T}(signal, widget, preserved)
+
+# convert a member of the range into a decimal 
+range2fraction(r::Range{T}, i::T) where T<:Number = (i - first(r) + step(r))/step(r)/length(r)
+
+"""
+    progressbar(range::Range; widget=nothing, signal=nothing)
+
+Create a progressbar displaying the current iteration in the given range; new iterations may be
+displayed by pushing to the widget. Note that iterators that are not members of the range are not 
+checkes for. Optionally specify
+  - the GtkProgressBar `widget` (by default, creates a new one)
+  - the (Reactive.jl) `signal` coupled to this progressbar (by default, creates a new signal)
+"""
+function progressbar(range::Range{T};
+               widget=nothing,
+               signal=nothing,
+               syncsig=true,
+               own=nothing) where T<:Number
+    value = first(range)
+    signalin = signal
+    signal, value = init_wsigval(T, signal, value)
+    if own == nothing
+        own = signal != signalin
+    end
+    if widget == nothing
+        widget = GtkProgressBar()
+    else
+        setproperty!(widget, :fraction, range2fraction(range, value))
+    end
+    preserved = []
+    if syncsig
+        push!(preserved, map(signal) do val
+            setproperty!(widget, :fraction, range2fraction(range, val))
+        end)
+    end
+    if own
+        ondestroy(widget, preserved)
+    end
+    ProgressBar(signal, widget, preserved)
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -205,6 +205,13 @@ include("tools.jl")
     destroy(s)
 
     @test_nowarn timewidget(Dates.Time(1,1,1))
+
+    p = progressbar(2:2:10)
+    push!(p, 4)
+    run_till_empty()
+    @test value(p) == 4
+    @test getproperty(p, :fraction, Float64) == 0.4
+
 end
 
 ## button


### PR DESCRIPTION
Fixes #54 

I didn't add any "fancy" clamping or membership-checks when pushing iterations because I feel that most use cases would link a `progressbar` to a real `for` loop or some other similar iteratable entity, and as such those checks are more relevant elsewhere. Simply put, if the iterator you're pushing into the `progressbar` comes from a `for` loop then it'll be fine.

Also, I'd like to bump #59 in the utmost polite way.  