### PR TITLE
Eliminate `yield` calls from within callbacks

### DIFF
--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -299,7 +299,11 @@ draw a red circle centered on `xsig`, `ysig`.
 """
 function Gtk.draw(drawfun::Function, c::Canvas, signals::Signal...)
     @guarded draw(c.widget) do widget
-        yield()  # allow the Gtk event queue to run
+        # This used to have a `yield` in it to allow the Gtk event queue to run,
+        # but that caused
+        # https://github.com/JuliaGraphics/Gtk.jl/issues/368
+        # and the bizarre failures in
+        # https://github.com/JuliaImages/ImageView.jl/pull/153
         drawfun(widget, map(value, signals)...)
     end
     drawsig = map((values...)->draw(c.widget), signals...)

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -567,8 +567,7 @@ function dropdown(; choices=nothing,
     push!(preserved, init_signal2widget(getactive, setactive!, widget, id, signal))
     if !allstrings
         choicedict = Dict(choices...)
-        # yield() seems to help when running under Pkg.test, not sure why
-        mappedsignal = map(val->(yield(); choicedict[val]), signal; typ=Any)
+        mappedsignal = map(val->choicedict[val], signal; typ=Any)
     else
         mappedsignal = Signal(nothing)
     end
@@ -963,7 +962,7 @@ end
 ProgressBar{T}(signal::Signal{T}, widget::GtkProgressBarLeaf, preserved) =
     ProgressBar{T}(signal, widget, preserved)
 
-# convert a member of the interval into a decimal 
+# convert a member of the interval into a decimal
 interval2fraction(x::AbstractInterval, i) = (i - minimum(x))/IntervalSets.width(x)
 
 """
@@ -984,7 +983,7 @@ julia> using IntervalSets
 julia> n = 10
 
 julia> pb = progressbar(1..n)
-Gtk.GtkProgressBarLeaf with 1: "input" = 1 Int64 
+Gtk.GtkProgressBarLeaf with 1: "input" = 1 Int64
 
 julia> for i = 1:n
            # do something


### PR DESCRIPTION
This proved to be the source of https://github.com/JuliaGraphics/Gtk.jl/issues/368.
Hopefully this won't hurt interactivity, but if so we have to find a new way;
fundamentally this has to go.
