### PR TITLE
Switch convert->constructor calls

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,5 +6,5 @@ FixedPointNumbers 0.3
 Reexport
 Reactive 0.4.0
 Graphics 0.2
-IntervalSets 0.0.5
+IntervalSets 0.3
 RoundingIntegers

--- a/examples/imageviewer.jl
+++ b/examples/imageviewer.jl
@@ -20,7 +20,7 @@ zoomsigs = init_zoom_rubberband(c, zr)
 # region of interest. This view will update anytime `zr` updates.
 imgsig = map(zr) do r
     cv = r.currentview
-    view(img, convert(UnitRange{Int}, cv.y), convert(UnitRange{Int}, cv.x))
+    view(img, UnitRange{Int}(cv.y), UnitRange{Int}(cv.x))
 end
 
 ## Turn on drawing for the canvas

--- a/src/GtkReactive.jl
+++ b/src/GtkReactive.jl
@@ -120,7 +120,7 @@ function Base.push!(zr::Signal{ZoomRegion{T}}, inds::Tuple{ClosedInterval,Closed
 end
 
 function Base.push!(zr::Signal{ZoomRegion{T}}, inds::Tuple{AbstractUnitRange,AbstractUnitRange}) where T
-    push!(zr, convert.(ClosedInterval{T}, inds))
+    push!(zr, ClosedInterval{T}.(inds))
 end
 
 Gtk.reveal(c::Canvas, args...) = reveal(c.widget, args...)

--- a/src/graphics_interaction.jl
+++ b/src/graphics_interaction.jl
@@ -369,14 +369,14 @@ constructed; these are used to reset to the original limits and to
 confine `zr.currentview`.
 """
 function ZoomRegion(inds::Tuple{AbstractUnitRange{I},AbstractUnitRange{I}}) where I<:Integer
-    ci = convert.(ClosedInterval{RInt}, inds)
+    ci = ClosedInterval{RInt}.(inds)
     fullview = XY(ci[2], ci[1])
     ZoomRegion(fullview, fullview)
 end
 function ZoomRegion(fullinds::Tuple{AbstractUnitRange{I},AbstractUnitRange{I}},
                     curinds::Tuple{AbstractUnitRange{I},AbstractUnitRange{I}}) where I<:Integer
-    fi = convert.(ClosedInterval{RInt}, fullinds)
-    ci = convert.(ClosedInterval{RInt}, curinds)
+    fi = ClosedInterval{RInt}.(fullinds)
+    ci = ClosedInterval{RInt}.(curinds)
     ZoomRegion(XY(fi[2], fi[1]), XY(ci[2], ci[1]))
 end
 ZoomRegion(img) = ZoomRegion(axes(img))
@@ -388,7 +388,7 @@ end
 
 reset(zr::ZoomRegion) = ZoomRegion(zr.fullview, zr.fullview)
 
-Base.axes(zr::ZoomRegion) = convert.(UnitRange, (zr.currentview.y, zr.currentview.x))
+Base.axes(zr::ZoomRegion) = UnitRange.((zr.currentview.y, zr.currentview.x))
 
 function interior(iv::ClosedInterval, limits::AbstractInterval)
     imin, imax = minimum(iv), maximum(iv)

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -1019,4 +1019,4 @@ function progressbar(interval::AbstractInterval{T};
     ProgressBar(signal, widget, preserved)
 end
 
-progressbar(range::AbstractRange; args...) = progressbar(convert(ClosedInterval, range), args...)
+progressbar(range::AbstractRange; args...) = progressbar(ClosedInterval(range), args...)


### PR DESCRIPTION
The new IntervalSets distinguishes more clearly between conversion and construction. When building one object which isn't entirely equivalent to another, construction is the correct choice.